### PR TITLE
Add Dockerfile and DockerHub link for container with pre-installed GoAT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ All of above are done through goatlib and tuning parameters such as global deadl
 \goat is available at \texttt{https://github.com/staheri/goat.git} and (ZENODO).
 We are working on a docker version of goat to make it available for schedule testing through test packages.
 ​
+## Download Pre-compiled GoAT Docker Container
+
+For quicker installation of GoAT, you can use a Docker container that comes pre-installed with the environment.
+- You can pull directly a container from `DockerHub`:
+```
+sudo docker pull fivosts/goat:latest
+```
+- Or you can build the container by yourself using our Dockerfile:
+```
+cd ./docker
+bash ./docker_build.sh
+```
+
+​
 ## Build GoAT Runtime
 
 GoAT is working in a custom runtime based on version [1.15.6](https://github.com/golang/go/tree/go1.15.6) of Golang currently only for Linux. It should be extensible to other architectures of the same version but they have not been tested.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,7 @@ RUN export GOPATH=$HOME/gopath;\
 RUN ln -nsf /usr/local/go-goat/go /usr/local/go
 
 WORKDIR /root
+RUN git clone https://github.com/goodmorning-coder/gobench.git
 RUN rm -rf /root/gopath/src/github.com/rivo/uniseg
 RUN wget https://github.com/rivo/uniseg/archive/refs/tags/v0.1.0.tar.gz
 RUN tar -xzvf v0.1.0.tar.gz -C /root/gopath/src/github.com/rivo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,82 @@
+FROM ubuntu:latest
+
+RUN apt update
+RUN apt install -y\
+  wget\
+  build-essential\
+  manpages-dev\
+  graphviz\
+  vim\
+  git\
+  bash
+
+SHELL ["/bin/bash", "-c"] 
+
+## Install everything to /root.
+WORKDIR /root/
+RUN wget https://golang.org/dl/go1.15.6.linux-amd64.tar.gz
+RUN mkdir -p /usr/local/go-goat
+RUN tar -xzvf go1.15.6.linux-amd64.tar.gz -C /usr/local
+RUN tar -xzvf go1.15.6.linux-amd64.tar.gz -C /usr/local/go-goat
+RUN mv /usr/local/go /usr/local/go-orig
+RUN ln -nsf /usr/local/go-orig /usr/local/go
+
+## Setup environment variables.
+RUN echo "export GOPATH=$HOME/gopath" >> /root/.bashrc
+RUN echo "export GOROOT=/usr/local/go" >> /root/.bashrc
+RUN echo "export PATH=$PATH:/usr/local/go/bin:$HOME/gopath/bin" >> /root/.bashrc
+RUN echo "export GOATWS=$HOME/goatws" >> /root/.bashrc
+RUN echo "export GOATTO=30" >> /root/.bashrc
+RUN echo "export GOATMAXPROCS=4" >> /root/.bashrc
+
+RUN mkdir /root/gopath
+RUN mkdir -p /root/goatws
+
+## Get GOAT tool.
+RUN export GOPATH=$HOME/gopath;\
+  export GOROOT=/usr/local/go;\
+  export PATH=$PATH:/usr/local/go/bin:$HOME/gopath/bin;\
+  export GOATWS=$HOME/goatws;\
+  export GOATTO=30;\
+  export GOATMAXPROCS=4;\
+  go get github.com/staheri/goat; exit 0
+
+## Install patch.
+WORKDIR /usr/local/go-goat/go
+RUN patch -p2 -d src/  < /root/gopath/src/github.com/staheri/goat/go1.15.6_goat_june15.patch; exit 0
+WORKDIR /usr/local/go-goat/go/src
+RUN export GOPATH=$HOME/gopath;\
+  export GOROOT=/usr/local/go;\
+  export PATH=$PATH:/usr/local/go/bin:$HOME/gopath/bin;\
+  export GOATWS=$HOME/goatws;\
+  export GOATTO=30;\
+  export GOATMAXPROCS=4;\
+  go get github.com/staheri/goat;\
+  export GOROOT_BOOTSTRAP=/usr/local/go-orig;\
+  ./make.bash
+RUN ln -nsf /usr/local/go-goat/go /usr/local/go
+
+WORKDIR /root
+RUN rm -rf /root/gopath/src/github.com/rivo/uniseg
+RUN wget https://github.com/rivo/uniseg/archive/refs/tags/v0.1.0.tar.gz
+RUN tar -xzvf v0.1.0.tar.gz -C /root/gopath/src/github.com/rivo
+RUN mv /root/gopath/src/github.com/rivo/uniseg-0.1.0 /root/gopath/src/github.com/rivo/uniseg
+RUN export GOPATH=$HOME/gopath;\
+  export GOROOT=/usr/local/go;\
+  export PATH=$PATH:/usr/local/go/bin:$HOME/gopath/bin;\
+  export GOATWS=$HOME/goatws;\
+  export GOATTO=30;\
+  export GOATMAXPROCS=4;\
+  go get github.com/staheri/goat; exit 0
+
+WORKDIR /root/gopath/src/github.com/staheri/goat
+RUN grep -rl "/home/saeed" . | xargs sed -i 's/\/home\/saeed/\/root/g'
+RUN export GOPATH=$HOME/gopath;\
+  export GOROOT=/usr/local/go;\
+  export PATH=$PATH:/usr/local/go/bin:$HOME/gopath/bin;\
+  export GOATWS=$HOME/goatws;\
+  export GOATTO=30;\
+  export GOATMAXPROCS=4;\
+  go build -o /root/gopath/bin/goat 
+
+CMD ["/bin/bash", "-c", "bash", ";", "source", "/root/.bashrc"]

--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo docker build --no-cache --tag goat:latest .

--- a/evaluate/evaluate.go
+++ b/evaluate/evaluate.go
@@ -37,7 +37,7 @@ var(
   comparison = []string{"goat_d0","goat_d1","goat_d2","goat_d3","goat_d4","builtinDL","goleak","lockDL"}
 )
 
-func EvaluateCoverage(configFile string, thresh int, isRace bool) {
+func EvaluateCoverage(configFile string, thresh int, isRace bool, json_trace bool) {
   colorReset := "\033[0m"
   colorRed := "\033[31m"
   colorGreen := "\033[32m"
@@ -199,7 +199,7 @@ func EvaluateCoverage(configFile string, thresh int, isRace bool) {
 
 iteration:for i:=0 ; i < thresh ; i++{
             fmt.Printf("Test %v on %v (%d/%d)\n",gex.Target.BugName,gex.ID,i+1,thresh)
-            res := gex.Execute(i,isRace)
+            res := gex.Execute(i,isRace, json_trace)
             if res.Detected{
             	fmt.Println(string(colorRed),res.Desc,string(colorReset))
               gex.Results = append(gex.Results,res)
@@ -264,7 +264,7 @@ iteration:for i:=0 ; i < thresh ; i++{
 
 }
 
-func EvaluateComparison(configFile string, thresh int){
+func EvaluateComparison(configFile string, thresh int, json_trace bool){
   var ex Ex
   colorReset := "\033[0m"
   colorRed := "\033[31m"
@@ -440,7 +440,7 @@ func EvaluateComparison(configFile string, thresh int){
             gex := ex.(*GoatExperiment)
             iteration:for i:=0 ; i < thresh ; i++{
               fmt.Printf("Test %v on %v (%d/%d)\n",gex.Target.BugName,gex.ID,i+1,thresh)
-              res := gex.Execute(i,false)
+              res := gex.Execute(i,false, json_trace)
               gex.Results = append(gex.Results,res)
               if res.Detected{
               	fmt.Println(string(colorRed),res.Desc,string(colorReset))
@@ -495,7 +495,7 @@ func EvaluateComparison(configFile string, thresh int){
                 break iteration2
               }
               fmt.Printf("Test %v on %v (%d/%d)\n",tex.Target.BugName,tex.ToolID,i+1,thresh)
-              res := tex.Execute(i,false)
+              res := tex.Execute(i,false, json_trace)
               tex.Results = append(tex.Results,res)
               if res.Detected{
               	fmt.Println(string(colorRed),res.Desc,string(colorReset))
@@ -543,7 +543,7 @@ func EvaluateComparison(configFile string, thresh int){
 
 }
 
-func EvaluateNonBlocking(configFile string,thresh int) {
+func EvaluateNonBlocking(configFile string,thresh int, json_trace bool) {
   identifier := "nonblocking"
   causes := ReadGoKerConfig(identifier)
 
@@ -606,7 +606,7 @@ func EvaluateNonBlocking(configFile string,thresh int) {
               gex := ex.(*GoatExperiment)
               IDD = gex.ID
               fmt.Printf("Test %v on %v (%d/%d)\n",gex.Target.BugName,gex.ID,i+1,thresh)
-              res := gex.Execute(i,true)
+              res := gex.Execute(i,true, json_trace)
               gex.Results = append(gex.Results,res)
               if res.Detected{
               	fmt.Println(string(colorRed),res.Desc,string(colorReset))
@@ -621,7 +621,7 @@ func EvaluateNonBlocking(configFile string,thresh int) {
               tex := ex.(*ToolExperiment)
               IDD = tex.ToolID
               fmt.Printf("Test %v on %v (%d/%d)\n",tex.Target.BugName,tex.ToolID,i+1,thresh)
-              res := tex.Execute(i,true)
+              res := tex.Execute(i,true, json_trace)
               tex.Results = append(tex.Results,res)
               if res.Detected{
               	fmt.Println(string(colorRed),res.Desc,string(colorReset))

--- a/evaluate/ex_execute.go
+++ b/evaluate/ex_execute.go
@@ -112,9 +112,11 @@ func (gex *GoatExperiment) Execute(i int, race bool) *Result {
         gex.UpdateCoverageReport()
         result.Coverage1 = gex.PrintCoverageReport(true)
         result.Coverage2 = gex.PrintCoverageReport(false)
-        // Parse trace
-        parseRes, err = trace.ParseTrace(execRes.TraceBuffer, filepath.Join(gex.PrefixDir,"bin",gex.BinaryName))
-        check(err)
+        
+        // Write trace to readable file.
+        file, _ := json.MarshalIndent(parseRes, "", " ")
+        _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
+        
         // analysis trace
         // measure coverage
         // detect result

--- a/evaluate/ex_execute.go
+++ b/evaluate/ex_execute.go
@@ -15,7 +15,7 @@ import(
   "bytes"
   "path/filepath"
   "time"
-  _"io",
+  _"io"
   "encoding/json"
   "io/ioutil"
 )

--- a/evaluate/ex_execute.go
+++ b/evaluate/ex_execute.go
@@ -22,7 +22,7 @@ import(
 
 
 // Execute and analyze Goat-experiment
-func (gex *GoatExperiment) Execute(i int, race bool) *Result {
+func (gex *GoatExperiment) Execute(i int, race bool, json_trace bool) *Result {
   // Deadlock detection
   // placeholder for results
     result := &Result{}
@@ -50,6 +50,12 @@ func (gex *GoatExperiment) Execute(i int, race bool) *Result {
     	check(err)
       // read trace time
       result.Time,_ = time.ParseDuration(traceops.ReadTime(filepath.Join(gex.PrefixDir,"traceTimes",traceName)+".time"))
+
+      if json_trace {
+        // Write trace to readable file.
+        file, _ := json.MarshalIndent(parseRes, "", " ")
+        _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
+      }
 
       if race { // results are already out there
         return result
@@ -113,9 +119,11 @@ func (gex *GoatExperiment) Execute(i int, race bool) *Result {
         result.Coverage1 = gex.PrintCoverageReport(true)
         result.Coverage2 = gex.PrintCoverageReport(false)
         
-        // Write trace to readable file.
-        file, _ := json.MarshalIndent(parseRes, "", " ")
-        _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
+        if json_trace {
+          // Write trace to readable file.
+          file, _ := json.MarshalIndent(parseRes, "", " ")
+          _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
+        }
         
         // analysis trace
         // measure coverage
@@ -151,8 +159,10 @@ func (gex *GoatExperiment) Execute(i int, race bool) *Result {
     } // parseRes is either obtained from execution or pre execution
 
 
-    file, _ := json.MarshalIndent(parseRes, "", " ")
-    _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
+    if json_trace{
+      file, _ := json.MarshalIndent(parseRes, "", " ")
+      _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
+    }
 
     fmt.Printf("\t# Events: %d\n",len(parseRes.Events))
     // print events
@@ -233,7 +243,7 @@ func (gex *GoatExperiment) Execute(i int, race bool) *Result {
 }
 
 // Execute and analyze Tool-experiment
-func (tex *ToolExperiment) Execute(i int,race bool) *Result {
+func (tex *ToolExperiment) Execute(i int,race bool, json_trace bool) *Result {
   // Variables
   var out []byte
   var err error
@@ -313,6 +323,12 @@ func (ex *ECTExperiment) Execute(i int, race bool) *Result {
 
     parseRes, err := trace.ParseTrace(execRes.TraceBuffer, filepath.Join(ex.PrefixDir,"bin",ex.BinaryName))
     check(err)
+
+    if json_trace {
+      // Write trace to readable file.
+      file, _ := json.MarshalIndent(parseRes, "", " ")
+      _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
+    }
 
     // parseRes holds events and stacktraces of trace
     fmt.Printf("\t# Events: %d\n",len(parseRes.Events))

--- a/evaluate/ex_execute.go
+++ b/evaluate/ex_execute.go
@@ -22,7 +22,7 @@ import(
 
 
 // Execute and analyze Goat-experiment
-func (gex *GoatExperiment) Execute(i int, race bool, json_trace bool) *Result {
+func (gex *GoatExperiment) Execute(i int, race bool) *Result {
   // Deadlock detection
   // placeholder for results
     result := &Result{}
@@ -243,7 +243,7 @@ func (gex *GoatExperiment) Execute(i int, race bool, json_trace bool) *Result {
 }
 
 // Execute and analyze Tool-experiment
-func (tex *ToolExperiment) Execute(i int,race bool, json_trace bool) *Result {
+func (tex *ToolExperiment) Execute(i int,race bool) *Result {
   // Variables
   var out []byte
   var err error
@@ -286,7 +286,7 @@ func (tex *ToolExperiment) Execute(i int,race bool, json_trace bool) *Result {
 }
 
 // Execute and analyze ECT-experiment
-func (ex *ECTExperiment) Execute(i int, race bool, json_trace bool) *Result {
+func (ex *ECTExperiment) Execute(i int, race bool) *Result {
   // set timeout
   old_TO := os.Getenv("GOATTO")
   os.Setenv("GOATTO","120")
@@ -327,7 +327,7 @@ func (ex *ECTExperiment) Execute(i int, race bool, json_trace bool) *Result {
     if json_trace {
       // Write trace to readable file.
       file, _ := json.MarshalIndent(parseRes, "", " ")
-      _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
+      _ = ioutil.WriteFile(filepath.Join(ex.TraceDir,traceName)+"-json.trace", file, 0644)
     }
 
     // parseRes holds events and stacktraces of trace

--- a/evaluate/ex_execute.go
+++ b/evaluate/ex_execute.go
@@ -15,7 +15,9 @@ import(
   "bytes"
   "path/filepath"
   "time"
-  _"io"
+  _"io",
+  "encoding/json"
+  "io/ioutil"
 )
 
 
@@ -143,6 +145,10 @@ func (gex *GoatExperiment) Execute(i int, race bool) *Result {
 
 
     } // parseRes is either obtained from execution or pre execution
+
+
+    file, _ := json.MarshalIndent(parseRes, "", " ")
+    _ = ioutil.WriteFile(filepath.Join(gex.TraceDir,traceName)+"-json.trace", file, 0644)
 
     fmt.Printf("\t# Events: %d\n",len(parseRes.Events))
     // print events

--- a/evaluate/ex_execute.go
+++ b/evaluate/ex_execute.go
@@ -286,7 +286,7 @@ func (tex *ToolExperiment) Execute(i int,race bool, json_trace bool) *Result {
 }
 
 // Execute and analyze ECT-experiment
-func (ex *ECTExperiment) Execute(i int, race bool) *Result {
+func (ex *ECTExperiment) Execute(i int, race bool, json_trace bool) *Result {
   // set timeout
   old_TO := os.Getenv("GOATTO")
   os.Setenv("GOATTO","120")

--- a/evaluate/ex_execute.go
+++ b/evaluate/ex_execute.go
@@ -112,7 +112,9 @@ func (gex *GoatExperiment) Execute(i int, race bool) *Result {
         gex.UpdateCoverageReport()
         result.Coverage1 = gex.PrintCoverageReport(true)
         result.Coverage2 = gex.PrintCoverageReport(false)
-
+        // Parse trace
+        parseRes, err = trace.ParseTrace(execRes.TraceBuffer, filepath.Join(gex.PrefixDir,"bin",gex.BinaryName))
+        check(err)
         // analysis trace
         // measure coverage
         // detect result

--- a/evaluate/ex_execute.go
+++ b/evaluate/ex_execute.go
@@ -22,7 +22,7 @@ import(
 
 
 // Execute and analyze Goat-experiment
-func (gex *GoatExperiment) Execute(i int, race bool) *Result {
+func (gex *GoatExperiment) Execute(i int, race bool, json_trace bool) *Result {
   // Deadlock detection
   // placeholder for results
     result := &Result{}
@@ -243,7 +243,7 @@ func (gex *GoatExperiment) Execute(i int, race bool) *Result {
 }
 
 // Execute and analyze Tool-experiment
-func (tex *ToolExperiment) Execute(i int,race bool) *Result {
+func (tex *ToolExperiment) Execute(i int,race bool, json_trace bool) *Result {
   // Variables
   var out []byte
   var err error
@@ -286,7 +286,7 @@ func (tex *ToolExperiment) Execute(i int,race bool) *Result {
 }
 
 // Execute and analyze ECT-experiment
-func (ex *ECTExperiment) Execute(i int, race bool) *Result {
+func (ex *ECTExperiment) Execute(i int, race bool, json_trace bool) *Result {
   // set timeout
   old_TO := os.Getenv("GOATTO")
   os.Setenv("GOATTO","120")

--- a/evaluate/ex_experiment.go
+++ b/evaluate/ex_experiment.go
@@ -32,7 +32,7 @@ type Ex interface{
   Init(bool)                 // init the experiments (bool: race)
   Instrument()               // instrument the program
   Build(bool)                // build the program (bool: race)
-  Execute(int,bool)    *Result    // execute the instrumented program (int: #iteration)
+  Execute(int,bool, bool)  *Result    // execute the instrumented program (int: #iteration)
 }
 
 // Struct for Bugs

--- a/evaluate/overhead.go
+++ b/evaluate/overhead.go
@@ -15,7 +15,7 @@ import(
 
 
 
-func EvaluateOverhead(configFile string, thresh int, ns []int) {
+func EvaluateOverhead(configFile string, thresh int, ns []int, json_trace bool) {
   identifier := "overhead"
 
   // obtain configName
@@ -72,7 +72,7 @@ func EvaluateOverhead(configFile string, thresh int, ns []int) {
           for i:=0 ; i < thresh ; i++{
             fmt.Printf("Test %v on %v (input:%s) (%d/%d)\nIDD:%v\n",ex.ID,ex.Target.BugName,strings.Join(ex.Args,"_"),i+1,thresh,IDD)
             //IDD = fmt.Sprintf("%v_%v_input:%s) (%d/%d)\n",ex.Target.BugName,ex.ID,strings.Join(ex.Args,"_"),i+1,thresh)
-            res := ex.Execute(i,false)
+            res := ex.Execute(i,false,json_trace)
             fmt.Printf("\tTime: %v\n",res.Time)
             ex.Results = append(ex.Results,res)
           }

--- a/evaluate/single.go
+++ b/evaluate/single.go
@@ -12,7 +12,7 @@ import(
   "github.com/jedib0t/go-pretty/table"
 )
 
-func EvaluateSingle(path string, freq, d int, isRace bool){
+func EvaluateSingle(path string, freq, d int, isRace bool, json_trace bool){
   colorReset := "\033[0m"
   colorRed := "\033[31m"
   colorGreen := "\033[32m"
@@ -158,7 +158,7 @@ func EvaluateSingle(path string, freq, d int, isRace bool){
 
 iteration:for i:=0 ; i < freq ; i++{
       fmt.Printf("Test %v on %v (%d/%d)\n",gex.Target.BugName,gex.ID,i+1,freq)
-      res := gex.Execute(i,isRace)
+      res := gex.Execute(i,isRace, json_trace)
       if res.Detected{
         fmt.Println(string(colorRed),res.Desc,string(colorReset))
         gex.Results = append(gex.Results,res)

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main(){
   }
   //evaluate.TAB_counts()
   //evaluate.EvaluateBlocking(flagPath,100)
-  evaluate.EvaluateNonBlocking(flagPath,500) // path to config , frequence,
+  evaluate.EvaluateNonBlocking(flagPath,500, flagJsonTrace) // path to config , frequence,
 
   //evaluate.EvaluateOverhead(flagPath,100,[]int{1,2,4,16,64,256,512,1024,2048})
   //

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ var (
   flagD               int
 	flagCoverage        bool
   flagRace            bool
+  flagJsonTrace       bool
   flagArgs            []string
 )
 
@@ -58,12 +59,12 @@ func main(){
 	}*/
 
   if flagPath != "" {
-    evaluate.EvaluateSingle(flagPath,flagFreq,flagD,flagRace)
+    evaluate.EvaluateSingle(flagPath,flagFreq,flagD,flagRace, flagJsonTrace)
   } else{
     if flagConf != ""{
-      evaluate.EvaluateComparison(flagConf,flagFreq)
+      evaluate.EvaluateComparison(flagConf,flagFreq, flagJsonTrace)
       if flagCoverage {
-        evaluate.EvaluateCoverage(flagConf,flagFreq,flagRace)
+        evaluate.EvaluateCoverage(flagConf,flagFreq,flagRace, flagJsonTrace)
       }
     }else{
       panic("GoAT: wrong args")
@@ -82,7 +83,7 @@ func main(){
 
   //customVis(flagPath,flagTool,true)
   //evaluate.EvaluateCoverage(flagPath,1000,false)
-  evaluate.EvaluateComparison(flagPath,1) // race = false
+  evaluate.EvaluateComparison(flagPath,1, flagJsonTrace) // race = false
   //evaluate.EvaluateComparison(flagPath,2,true) // race = true
   //evaluate.TraceSnippet(flagPath)
 
@@ -99,6 +100,7 @@ func parseFlags() {
   flag.IntVar(&flagFreq, "freq", 1, "frequency of executions")
   flag.BoolVar(&flagCoverage,"cov",false,"include coverage report in evaluation")
   flag.BoolVar(&flagRace,"race",false,"enable race detection")
+  flag.BoolVar(&flagJsonTrace,"json_trace",false,"enable collection of execution traces in readable JSON format.")
 
 	flag.Parse()
 


### PR DESCRIPTION
- To save the hassle of manually installing the tool and debugging the installation process, simply build from Dockerfile or pull from DockerHub.
- The Dockerfile can be used as an updated example of how to successfully install GoAT locally.